### PR TITLE
 add package: gookit/gcli

### DIFF
--- a/en_US/README.md
+++ b/en_US/README.md
@@ -93,6 +93,7 @@
 
 *Libraries for building Console Applications and Console User Interfaces*
 
+- [gcli](https://github.com/gookit/gcli) Go CLI application, tool library, running CLI commands, support console color, user interaction, progress display, data formatting display, generate bash/zsh completion add more features.
 
 ## Configuration
 

--- a/zh_CN/README.md
+++ b/zh_CN/README.md
@@ -112,6 +112,7 @@ _以上标准均不是绝对条件。我们会进行权衡，并尽量提升本�
 
 *Libraries for building Console Applications and Console User Interfaces*
 
+- [gcli](https://github.com/gookit/gcli) Go的命令行应用，工具库，运行CLI命令，支持命令行色彩、用户交互、进度显示、数据格式化显示、生成bash/zsh命令补全脚本
 
 ## Configuration
 


### PR DESCRIPTION
[gcli](https://github.com/gookit/gcli): Go的命令行应用，工具库，运行CLI命令，支持命令行色彩、用户交互、进度显示、数据格式化显示、生成bash/zsh命令补全脚本

**Please provide package links to:**
* github.com repo: [gookit/gcli](https://github.com/gookit/gcli)
* godoc.org: [![GoDoc](https://godoc.org/github.com/gookit/gcli?status.svg)](https://godoc.org/github.com/gookit/gcli)
* goreportcard.com: [![Go Report Card](https://goreportcard.com/badge/github.com/gookit/gcli)](https://goreportcard.com/report/github.com/gookit/gcli)

gookit: https://github.com/gookit